### PR TITLE
Fix indentation in env var definition

### DIFF
--- a/hlm/apiworker/templates/deployment.yaml
+++ b/hlm/apiworker/templates/deployment.yaml
@@ -31,12 +31,12 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: apiworker
-                key: "postmark.token.account"
+                  key: "postmark.token.account"
             - name: APIWORKER_POSTMARK_TOKEN_SERVER
               valueFrom:
                 secretKeyRef:
                   name: apiworker
-                key: "postmark.token.server"
+                  key: "postmark.token.server"
           resources:
             limits:
               cpu: "100m"


### PR DESCRIPTION
Fixing `{"level":"error","ts":"2021-05-30T19:18:00.120Z","logger":"controller.helmrelease","msg":"Reconciler error","reconciler group":"helm.toolkit.fluxcd.io","reconciler kind":"HelmRelease","name":"apiworker","namespace":"infra","error":"Helm install failed: unable to build kubernetes objects from release manifest: error validating \"\": error validating data: [ValidationError(Deployment.spec.template.spec.containers[0].env[0].valueFrom): unknown field \"key\" in io.k8s.api.core.v1.EnvVarSource, ValidationError(Deployment.spec.template.spec.containers[0].env[0].valueFrom.secretKeyRef): missing required field \"key\" in io.k8s.api.core.v1.SecretKeySelector, ValidationError(Deployment.spec.template.spec.containers[0].env[1].valueFrom): unknown field \"key\" in io.k8s.api.core.v1.EnvVarSource, ValidationError(Deployment.spec.template.spec.containers[0].env[1].valueFrom.secretKeyRef): missing required field \"key\" in io.k8s.api.core.v1.SecretKeySelector]"}`